### PR TITLE
Fuse evolve_implicit into a per-cell kernel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,11 @@ repos:
       - id: check-yaml
         exclude: ^data/
 
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
     hooks:
       - id: clang-format
         name: Fix *.c,*.cc,*.cpp,*.h,*.hpp
-        entry: clang-format
-        language: system
         files: ^(src|python|tools|tests|examples)/.*\.(c|cc|cpp|h|hpp)$
         exclude: ^(src/opacity/microwave)/.*\.(c|cc|cpp|h|hpp)$
         args: ["-i", "-style=Google"]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ if (CUDAToolkit_FOUND)
     utils/*.cu
     thermo/*.cu
     math/*.cu
+    kinetics/*.cu
     )
 
   add_library(${namel}_cuda_${buildl}

--- a/src/kinetics/evolve_implicit.hpp
+++ b/src/kinetics/evolve_implicit.hpp
@@ -1,11 +1,7 @@
 #pragma once
 
 // torch
-#include <ATen/TensorIterator.h>
 #include <torch/torch.h>
-
-// kintera
-#include "evolve_implicit_dispatch.hpp"
 
 namespace kintera {
 
@@ -15,41 +11,20 @@ namespace kintera {
 //! matrix, J is the reaction-space Jacobian, and rate is the vector of
 //! reaction rates. Supports batched layers via leading dimensions.
 //!
+//! Defined out-of-line in evolve_implicit_dispatch.cpp (not inline): it calls a
+//! DECLARE_DISPATCH stub, whose DispatchStubImpl::get_call_ptr arity is gated
+//! by torch's AVX feature macros. Keeping the definition in the kintera library
+//! (built with those macros via Caffe2) ensures the get_call_ptr reference is
+//! never compiled into a downstream consumer (e.g. the pybind module) that was
+//! built without them.
+//!
 //! @param rate     reaction rates, shape (..., nreaction)
 //! @param stoich   stoichiometric matrix, shape (nspecies, nreaction)
 //! @param jacobian reaction-space Jacobian, shape (..., nreaction, nspecies)
 //! @param dt       time step
 //! @return         concentration change delta, shape (..., nspecies)
-inline torch::Tensor evolve_implicit(torch::Tensor rate, torch::Tensor stoich,
-                                     torch::Tensor jacobian, double dt) {
-  auto nspecies = stoich.size(0);
-
-  // Per-cell fused solve of  A * delta = SR  where  A = I/dt - S*J  and
-  // SR = S*rate. This replaces the batched stoich.matmul(jacobian) GEMM and
-  // the batched linalg_solve (getrf/getrs) with a single per-cell kernel,
-  // each cell building and solving its own tiny (nspecies x nspecies) system.
-  auto rate_c = rate.contiguous();
-  // jacobian: (..., nreaction, nspecies) -> (..., nreaction*nspecies)
-  auto jac2d = jacobian.contiguous().flatten(-2, -1);
-  auto stoich_c = stoich.contiguous();
-
-  auto out_sizes = rate_c.sizes().vec();
-  out_sizes.back() = nspecies;
-  auto delta = torch::empty(out_sizes, rate_c.options());
-
-  auto iter = at::TensorIteratorConfig()
-                  .resize_outputs(false)
-                  .check_all_same_dtype(false)
-                  .declare_static_shape(delta.sizes(),
-                                        /*squash_dims=*/{delta.dim() - 1})
-                  .add_output(delta)
-                  .add_input(rate_c)
-                  .add_input(jac2d)
-                  .build();
-
-  at::native::call_evolve_implicit(rate_c.device().type(), iter, stoich_c, dt);
-  return delta;
-}
+torch::Tensor evolve_implicit(torch::Tensor rate, torch::Tensor stoich,
+                              torch::Tensor jacobian, double dt);
 
 //! Two-stage Rosenbrock (Ros2) solver for stiff chemical kinetics.
 //!

--- a/src/kinetics/evolve_implicit.hpp
+++ b/src/kinetics/evolve_implicit.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 // torch
+#include <ATen/TensorIterator.h>
 #include <torch/torch.h>
+
+// kintera
+#include "evolve_implicit_dispatch.hpp"
 
 namespace kintera {
 
@@ -19,15 +23,32 @@ namespace kintera {
 inline torch::Tensor evolve_implicit(torch::Tensor rate, torch::Tensor stoich,
                                      torch::Tensor jacobian, double dt) {
   auto nspecies = stoich.size(0);
-  auto eye = torch::eye(nspecies, rate.options());
-  auto SJ = stoich.matmul(jacobian);
-  auto SR = stoich.matmul(rate.unsqueeze(-1)).squeeze(-1);
-  auto A = eye / dt - SJ;
-  try {
-    return torch::linalg_solve(A, SR.unsqueeze(-1)).squeeze(-1);
-  } catch (const c10::Error&) {
-    return std::get<0>(torch::linalg_lstsq(A, SR.unsqueeze(-1))).squeeze(-1);
-  }
+
+  // Per-cell fused solve of  A * delta = SR  where  A = I/dt - S*J  and
+  // SR = S*rate. This replaces the batched stoich.matmul(jacobian) GEMM and
+  // the batched linalg_solve (getrf/getrs) with a single per-cell kernel,
+  // each cell building and solving its own tiny (nspecies x nspecies) system.
+  auto rate_c = rate.contiguous();
+  // jacobian: (..., nreaction, nspecies) -> (..., nreaction*nspecies)
+  auto jac2d = jacobian.contiguous().flatten(-2, -1);
+  auto stoich_c = stoich.contiguous();
+
+  auto out_sizes = rate_c.sizes().vec();
+  out_sizes.back() = nspecies;
+  auto delta = torch::empty(out_sizes, rate_c.options());
+
+  auto iter = at::TensorIteratorConfig()
+                  .resize_outputs(false)
+                  .check_all_same_dtype(false)
+                  .declare_static_shape(delta.sizes(),
+                                        /*squash_dims=*/{delta.dim() - 1})
+                  .add_output(delta)
+                  .add_input(rate_c)
+                  .add_input(jac2d)
+                  .build();
+
+  at::native::call_evolve_implicit(rate_c.device().type(), iter, stoich_c, dt);
+  return delta;
 }
 
 //! Two-stage Rosenbrock (Ros2) solver for stiff chemical kinetics.

--- a/src/kinetics/evolve_implicit_dispatch.cpp
+++ b/src/kinetics/evolve_implicit_dispatch.cpp
@@ -6,12 +6,45 @@
 #include <ATen/Parallel.h>
 #include <ATen/TensorIterator.h>
 #include <ATen/native/ReduceOpsUtils.h>
+#include <torch/torch.h>
 
 // kintera
+#include "evolve_implicit.hpp"
 #include "evolve_implicit_dispatch.hpp"
 #include "evolve_implicit_impl.h"
 
 namespace kintera {
+
+torch::Tensor evolve_implicit(torch::Tensor rate, torch::Tensor stoich,
+                              torch::Tensor jacobian, double dt) {
+  auto nspecies = stoich.size(0);
+
+  // Per-cell fused solve of  A * delta = SR  where  A = I/dt - S*J  and
+  // SR = S*rate. This replaces the batched stoich.matmul(jacobian) GEMM and
+  // the batched linalg_solve (getrf/getrs) with a single per-cell kernel,
+  // each cell building and solving its own tiny (nspecies x nspecies) system.
+  auto rate_c = rate.contiguous();
+  // jacobian: (..., nreaction, nspecies) -> (..., nreaction*nspecies)
+  auto jac2d = jacobian.contiguous().flatten(-2, -1);
+  auto stoich_c = stoich.contiguous();
+
+  auto out_sizes = rate_c.sizes().vec();
+  out_sizes.back() = nspecies;
+  auto delta = torch::empty(out_sizes, rate_c.options());
+
+  auto iter = at::TensorIteratorConfig()
+                  .resize_outputs(false)
+                  .check_all_same_dtype(false)
+                  .declare_static_shape(delta.sizes(),
+                                        /*squash_dims=*/{delta.dim() - 1})
+                  .add_output(delta)
+                  .add_input(rate_c)
+                  .add_input(jac2d)
+                  .build();
+
+  at::native::call_evolve_implicit(rate_c.device().type(), iter, stoich_c, dt);
+  return delta;
+}
 
 void call_evolve_implicit_cpu(at::TensorIterator& iter,
                               at::Tensor const& stoich, double dt) {

--- a/src/kinetics/evolve_implicit_dispatch.cpp
+++ b/src/kinetics/evolve_implicit_dispatch.cpp
@@ -1,0 +1,52 @@
+// C/C++
+#include <vector>
+
+// torch
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/ReduceOpsUtils.h>
+
+// kintera
+#include "evolve_implicit_dispatch.hpp"
+#include "evolve_implicit_impl.h"
+
+namespace kintera {
+
+void call_evolve_implicit_cpu(at::TensorIterator& iter,
+                              at::Tensor const& stoich, double dt) {
+  int grain_size = iter.numel() / std::max(1, at::get_num_threads());
+
+  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "call_evolve_implicit_cpu", [&] {
+    int nspecies = at::native::ensure_nonempty_size(stoich, 0);
+    int nreaction = at::native::ensure_nonempty_size(stoich, 1);
+
+    auto stoich_ptr = stoich.data_ptr<scalar_t>();
+    scalar_t inv_dt = static_cast<scalar_t>(1.0 / dt);
+    size_t mem_size = evolve_implicit_space<scalar_t>(nspecies, nreaction);
+
+    iter.for_each(
+        [&](char** data, const int64_t* strides, int64_t n) {
+          std::vector<char> work(mem_size);
+          for (int i = 0; i < n; i++) {
+            auto delta = reinterpret_cast<scalar_t*>(data[0] + i * strides[0]);
+            auto rate = reinterpret_cast<scalar_t*>(data[1] + i * strides[1]);
+            auto jac = reinterpret_cast<scalar_t*>(data[2] + i * strides[2]);
+            evolve_implicit_cell(delta, rate, jac, stoich_ptr, nspecies,
+                                 nreaction, inv_dt, work.data());
+          }
+        },
+        grain_size);
+  });
+}
+
+}  // namespace kintera
+
+namespace at::native {
+
+DEFINE_DISPATCH(call_evolve_implicit);
+
+REGISTER_ALL_CPU_DISPATCH(call_evolve_implicit,
+                          &kintera::call_evolve_implicit_cpu);
+
+}  // namespace at::native

--- a/src/kinetics/evolve_implicit_dispatch.cu
+++ b/src/kinetics/evolve_implicit_dispatch.cu
@@ -1,0 +1,47 @@
+// torch
+#include <ATen/Dispatch.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/ReduceOpsUtils.h>
+#include <c10/cuda/CUDAGuard.h>
+
+// kintera
+#include <kintera/loops.cuh>
+
+#include "evolve_implicit_dispatch.hpp"
+#include "evolve_implicit_impl.h"
+
+namespace kintera {
+
+void call_evolve_implicit_cuda(at::TensorIterator& iter,
+                               at::Tensor const& stoich, double dt) {
+  at::cuda::CUDAGuard device_guard(iter.device());
+
+  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "call_evolve_implicit_cuda", [&] {
+    int nspecies = at::native::ensure_nonempty_size(stoich, 0);
+    int nreaction = at::native::ensure_nonempty_size(stoich, 1);
+
+    auto stoich_ptr = stoich.data_ptr<scalar_t>();
+    scalar_t inv_dt = static_cast<scalar_t>(1.0 / dt);
+    int mem_size = evolve_implicit_space<scalar_t>(nspecies, nreaction);
+
+    native::gpu_mem_kernel<32, 3>(
+        iter, mem_size,
+        [=] GPU_LAMBDA(char* const data[3], unsigned int strides[3],
+                       char* work) {
+          auto delta = reinterpret_cast<scalar_t*>(data[0] + strides[0]);
+          auto rate = reinterpret_cast<scalar_t*>(data[1] + strides[1]);
+          auto jac = reinterpret_cast<scalar_t*>(data[2] + strides[2]);
+          evolve_implicit_cell(delta, rate, jac, stoich_ptr, nspecies,
+                               nreaction, inv_dt, work);
+        });
+  });
+}
+
+}  // namespace kintera
+
+namespace at::native {
+
+REGISTER_CUDA_DISPATCH(call_evolve_implicit,
+                       &kintera::call_evolve_implicit_cuda);
+
+}  // namespace at::native

--- a/src/kinetics/evolve_implicit_dispatch.hpp
+++ b/src/kinetics/evolve_implicit_dispatch.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+// torch
+#include <ATen/TensorIterator.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at::native {
+
+using evolve_implicit_fn = void (*)(at::TensorIterator& iter,
+                                    at::Tensor const& stoich, double dt);
+
+DECLARE_DISPATCH(evolve_implicit_fn, call_evolve_implicit);
+
+}  // namespace at::native

--- a/src/kinetics/evolve_implicit_impl.h
+++ b/src/kinetics/evolve_implicit_impl.h
@@ -50,7 +50,8 @@ size_t evolve_implicit_space(int nspecies, int nreaction) {
  *             (nspecies, nreaction). Shared (constant) across all cells.
  * \param[in]  nspecies, nreaction    system dimensions.
  * \param[in]  inv_dt                 1 / dt.
- * \param[in]  work                   per-thread scratch, >= evolve_implicit_space.
+ * \param[in]  work                   per-thread scratch, >=
+ * evolve_implicit_space.
  */
 template <typename T>
 DISPATCH_MACRO void evolve_implicit_cell(T* delta, const T* rate, const T* jac,
@@ -69,8 +70,7 @@ DISPATCH_MACRO void evolve_implicit_cell(T* delta, const T* rate, const T* jac,
 
   for (int i = 0; i < nspecies; ++i)
     for (int k = 0; k < nspecies; ++k)
-      A[i * nspecies + k] =
-          (i == k ? inv_dt : T(0)) - A[i * nspecies + k];
+      A[i * nspecies + k] = (i == k ? inv_dt : T(0)) - A[i * nspecies + k];
 
   // primary path: dense LU with partial pivoting on a destroyable copy
   for (int t = 0; t < nspecies * nspecies; ++t) Alu[t] = A[t];

--- a/src/kinetics/evolve_implicit_impl.h
+++ b/src/kinetics/evolve_implicit_impl.h
@@ -1,0 +1,89 @@
+#pragma once
+
+// C/C++
+#include <cmath>
+#include <cstring>
+
+// base
+#include <configure.h>
+
+// kintera
+#include <kintera/math/core.h>
+#include <kintera/math/psolve.h>
+#include <kintera/utils/alloc.h>
+
+namespace kintera {
+
+/*!
+ * \brief Per-thread scratch size (bytes) for evolve_implicit_cell.
+ *
+ * Layout: A[n*n] (kept for the singular fallback) + Alu[n*n] (destroyed by the
+ * LU solve) + sr[n] (rhs, kept) + x[n] (working rhs -> solution) + the psolve
+ * pseudo-inverse workspace.
+ */
+template <typename T>
+size_t evolve_implicit_space(int nspecies, int nreaction) {
+  size_t bytes = 0;
+  auto bump = [&](size_t align, size_t nbytes) {
+    bytes = static_cast<size_t>(align_up(bytes, align)) + nbytes;
+  };
+  bump(alignof(T), nspecies * nspecies * sizeof(T));  // A
+  bump(alignof(T), nspecies * nspecies * sizeof(T));  // Alu
+  bump(alignof(T), nspecies * sizeof(T));             // sr
+  bump(alignof(T), nspecies * sizeof(T));             // x
+  return bytes + psolve_space<T>(nspecies);           // psolve workspace
+}
+
+/*!
+ * \brief Single-cell implicit Euler kinetics solve.
+ *
+ * Builds A = I/dt - S*J and SR = S*rate for one cell, then solves A*delta = SR.
+ * This fuses the batched stoich.matmul(jacobian) GEMM and the batched LU that
+ * torch performs in evolve_implicit into one per-cell computation, eliminating
+ * the cuBLAS tiny-matrix batched-GEMM and the batched getrf/getrs.
+ *
+ * \param[out] delta[0..nspecies-1]   concentration change for this cell.
+ * \param[in]  rate[0..nreaction-1]   reaction rates for this cell.
+ * \param[in]  jac[0..nreaction*nspecies-1]  reaction-space Jacobian, row-major
+ *             (nreaction, nspecies).
+ * \param[in]  stoich[0..nspecies*nreaction-1]  stoichiometric matrix, row-major
+ *             (nspecies, nreaction). Shared (constant) across all cells.
+ * \param[in]  nspecies, nreaction    system dimensions.
+ * \param[in]  inv_dt                 1 / dt.
+ * \param[in]  work                   per-thread scratch, >= evolve_implicit_space.
+ */
+template <typename T>
+DISPATCH_MACRO void evolve_implicit_cell(T* delta, const T* rate, const T* jac,
+                                         const T* stoich, int nspecies,
+                                         int nreaction, T inv_dt, char* work) {
+  char* cur = work;
+  T* A = alloc_from<T>(cur, nspecies * nspecies);
+  T* Alu = alloc_from<T>(cur, nspecies * nspecies);
+  T* sr = alloc_from<T>(cur, nspecies);
+  T* x = alloc_from<T>(cur, nspecies);
+  char* pw = cur;  // remaining scratch is the psolve workspace
+
+  // A = S * J  (then turned into I/dt - S*J below);  sr = S * rate
+  mmdot(A, stoich, jac, nspecies, nreaction, nspecies);
+  mvdot(sr, stoich, rate, nspecies, nreaction);
+
+  for (int i = 0; i < nspecies; ++i)
+    for (int k = 0; k < nspecies; ++k)
+      A[i * nspecies + k] =
+          (i == k ? inv_dt : T(0)) - A[i * nspecies + k];
+
+  // primary path: dense LU with partial pivoting on a destroyable copy
+  for (int t = 0; t < nspecies * nspecies; ++t) Alu[t] = A[t];
+  for (int t = 0; t < nspecies; ++t) x[t] = sr[t];
+
+  if (!dsolve_lu(Alu, x, nspecies)) {
+    // singular cell: minimum-norm least-squares via pseudo-inverse, matching
+    // the linalg_lstsq fallback in the original torch implementation.
+    for (int t = 0; t < nspecies; ++t) x[t] = sr[t];
+    psolve(x, A, nspecies, pw);
+  }
+
+  for (int t = 0; t < nspecies; ++t) delta[t] = x[t];
+}
+
+}  // namespace kintera

--- a/src/kinetics/sri_falloff.hpp
+++ b/src/kinetics/sri_falloff.hpp
@@ -64,10 +64,10 @@ struct SRIFalloffOptionsImpl {
   ADD_ARG(std::vector<double>, sri_A) = {};
   ADD_ARG(std::vector<double>, sri_B) = {};
   ADD_ARG(std::vector<double>, sri_C) = {};
-  ADD_ARG(std::vector<double>, sri_D) = {
-  };  // 1.0 for 3-param, variable for 5-param
-  ADD_ARG(std::vector<double>, sri_E) = {
-  };  // 0.0 for 3-param, variable for 5-param
+  ADD_ARG(std::vector<double>,
+          sri_D) = {};  // 1.0 for 3-param, variable for 5-param
+  ADD_ARG(std::vector<double>,
+          sri_E) = {};  // 0.0 for 3-param, variable for 5-param
 
   // Per-reaction third-body efficiencies
   ADD_ARG(std::vector<Composition>, efficiencies) = {};

--- a/src/kinetics/sri_falloff.hpp
+++ b/src/kinetics/sri_falloff.hpp
@@ -64,10 +64,10 @@ struct SRIFalloffOptionsImpl {
   ADD_ARG(std::vector<double>, sri_A) = {};
   ADD_ARG(std::vector<double>, sri_B) = {};
   ADD_ARG(std::vector<double>, sri_C) = {};
-  ADD_ARG(std::vector<double>,
-          sri_D) = {};  // 1.0 for 3-param, variable for 5-param
-  ADD_ARG(std::vector<double>,
-          sri_E) = {};  // 0.0 for 3-param, variable for 5-param
+  // 1.0 for 3-param, variable for 5-param
+  ADD_ARG(std::vector<double>, sri_D) = {};
+  // 0.0 for 3-param, variable for 5-param
+  ADD_ARG(std::vector<double>, sri_E) = {};
 
   // Per-reaction third-body efficiencies
   ADD_ARG(std::vector<Composition>, efficiencies) = {};

--- a/src/kinetics/troe_falloff.hpp
+++ b/src/kinetics/troe_falloff.hpp
@@ -64,8 +64,8 @@ struct TroeFalloffOptionsImpl {
   ADD_ARG(std::vector<double>, troe_A) = {};
   ADD_ARG(std::vector<double>, troe_T3) = {};
   ADD_ARG(std::vector<double>, troe_T1) = {};
-  ADD_ARG(std::vector<double>, troe_T2) = {
-  };  // 0.0 for 3-param, non-zero for 4-param
+  ADD_ARG(std::vector<double>,
+          troe_T2) = {};  // 0.0 for 3-param, non-zero for 4-param
 
   // Per-reaction third-body efficiencies
   ADD_ARG(std::vector<Composition>, efficiencies) = {};

--- a/src/kinetics/troe_falloff.hpp
+++ b/src/kinetics/troe_falloff.hpp
@@ -64,8 +64,8 @@ struct TroeFalloffOptionsImpl {
   ADD_ARG(std::vector<double>, troe_A) = {};
   ADD_ARG(std::vector<double>, troe_T3) = {};
   ADD_ARG(std::vector<double>, troe_T1) = {};
-  ADD_ARG(std::vector<double>,
-          troe_T2) = {};  // 0.0 for 3-param, non-zero for 4-param
+  // 0.0 for 3-param, non-zero for 4-param
+  ADD_ARG(std::vector<double>, troe_T2) = {};
 
   // Per-reaction third-body efficiencies
   ADD_ARG(std::vector<Composition>, efficiencies) = {};

--- a/src/math/core.h
+++ b/src/math/core.h
@@ -164,4 +164,56 @@ DISPATCH_MACRO void matmul_ATA(T* ATA, const T* A, int n) {
     }
 }
 
+/*!
+ * \brief Solve A x = b for a dense system by Gaussian elimination with partial
+ *        pivoting. Mirrors the LU-with-pivoting path of cuBLAS getrf/getrs.
+ * \param[in,out] A[0..n*n-1] row-major n x n matrix, destroyed in place.
+ * \param[in,out] b[0..n-1]   right-hand side on input, solution on output.
+ * \param[in] n               system dimension.
+ * \return true on success, false if an exactly singular pivot was found (the
+ *         caller should fall back to a least-squares / pseudo-inverse solve).
+ */
+template <typename T>
+DISPATCH_MACRO bool dsolve_lu(T* A, T* b, int n) {
+  for (int k = 0; k < n; ++k) {
+    // partial pivot: largest |A[i][k]| for i >= k
+    int piv = k;
+    T maxv = fabs(A[k * n + k]);
+    for (int i = k + 1; i < n; ++i) {
+      T v = fabs(A[i * n + k]);
+      if (v > maxv) {
+        maxv = v;
+        piv = i;
+      }
+    }
+    if (maxv == 0.0) return false;  // exactly singular column
+
+    if (piv != k) {
+      for (int j = k; j < n; ++j) {
+        T t = A[k * n + j];
+        A[k * n + j] = A[piv * n + j];
+        A[piv * n + j] = t;
+      }
+      T tb = b[k];
+      b[k] = b[piv];
+      b[piv] = tb;
+    }
+
+    T akk = A[k * n + k];
+    for (int i = k + 1; i < n; ++i) {
+      T f = A[i * n + k] / akk;
+      for (int j = k + 1; j < n; ++j) A[i * n + j] -= f * A[k * n + j];
+      b[i] -= f * b[k];
+    }
+  }
+
+  // back substitution
+  for (int i = n - 1; i >= 0; --i) {
+    T s = b[i];
+    for (int j = i + 1; j < n; ++j) s -= A[i * n + j] * b[j];
+    b[i] = s / A[i * n + i];
+  }
+  return true;
+}
+
 }  // namespace kintera

--- a/tests/test_jup_thermo.cpp
+++ b/tests/test_jup_thermo.cpp
@@ -167,11 +167,11 @@ TEST_F(TestThermodynamics, thermodynamics) {
   for (auto& v : entropy) v *= Constants::Rgas;
 
   for (int i = 0; i < Thermodynamics::Size; ++i) {
-    std::cout << "cv[" << i << "] = " << cv[i] << ", "
-              << "cp[" << i << "] = " << cp[i] << ", "
-              << "enthalpy[" << i << "] = " << enthalpy[i] << ", "
-              << "entropy[" << i << "] = " << entropy[i] << ", "
-              << "intEng[" << i << "] = " << intEng[i] << std::endl;
+    std::cout << "cv[" << i << "] = " << cv[i] << ", " << "cp[" << i
+              << "] = " << cp[i] << ", " << "enthalpy[" << i
+              << "] = " << enthalpy[i] << ", " << "entropy[" << i
+              << "] = " << entropy[i] << ", " << "intEng[" << i
+              << "] = " << intEng[i] << std::endl;
   }
 }
 


### PR DESCRIPTION
The implicit kinetics solve built the system matrix with a batched stoich.matmul(jacobian) GEMM and solved it with torch's batched LU (linalg_solve). At 100^3 cells the GEMM is one batched matmul that cuBLAS splits into 19 launches per cycle (batch 106^3 > gridZ cap), and together with the batched getrf/trsm it cost ~70 ms/cycle of tiny-matrix (M=N=nspecies, K=nreaction) linear algebra in the Jupiter CRM run.

Replace it with a single per-cell kernel: each cell builds A = I/dt - S*J and SR = S*rate and solves the tiny dense system with Gaussian elimination
+ partial pivoting (new dsolve_lu in math/core.h), falling back to psolve (pseudo-inverse) for singular cells - per cell, so no full-batch SVD. This mirrors the thermo_dispatch + gpu_mem_kernel pattern and keeps a CPU path.

Results (nsys, 100^3): gemmSN_TN/getrf/trsm gone; kinetics solve 70.7 -> ~17 ms/cycle (~4.2x); per-cycle GPU time 250.9 -> 192.0 ms (1.31x). Bit-close: matches the original torch formula to ~1e-11 rel, CPU==CUDA to 1e-17; test_kinetics and test_chapman_cycle pass.