### PR TITLE
Fix rain-out entropy bookkeeping in the pseudo-adiabat builder (extrapolate_dz/dlnp)

### DIFF
--- a/src/species.cpp
+++ b/src/species.cpp
@@ -165,7 +165,7 @@ void init_species_from_yaml(YAML::Node const& config) {
     }
 
     if (sp["s0_R"]) {
-      species_sref_R.push_back(sp["u0_R"].as<double>());
+      species_sref_R.push_back(sp["s0_R"].as<double>());
     } else {
       species_sref_R.push_back(0.);
     }

--- a/src/thermo/eval_uhs.cpp
+++ b/src/thermo/eval_uhs.cpp
@@ -183,7 +183,7 @@ torch::Tensor eval_entropy_R(torch::Tensor temp, torch::Tensor pres,
   entropy_R.narrow(-1, 0, ngas) =
       sref_R.narrow(0, 0, ngas) + entropy_R_extra +
       temp.log().unsqueeze(-1) * cp_gas_R - pres.log().unsqueeze(-1) -
-      (conc_gas / conc_gas.sum(-1, /*keepdim=*/true)).log();
+      (conc_gas / conc_gas.sum(-1, /*keepdim=*/true)).clamp_min(1e-300).log();
 
   // std::cout << "entropy_R = " << entropy_R << std::endl;
 
@@ -243,7 +243,7 @@ torch::Tensor eval_entropy_R(torch::Tensor temp, torch::Tensor pres,
   entropy_R.narrow(-1, 0, ngas) =
       sref_R.narrow(0, 0, ngas) + entropy_R_extra +
       temp.log().unsqueeze(-1) * cp_gas_R - pres.log().unsqueeze(-1) -
-      (conc_gas / conc_gas.sum(-1, /*keepdim=*/true)).log();
+      (conc_gas / conc_gas.sum(-1, /*keepdim=*/true)).clamp_min(1e-300).log();
 
   //////////// Evaluate condensate entropy ////////////
 

--- a/src/thermo/extrapolate_ad.cpp
+++ b/src/thermo/extrapolate_ad.cpp
@@ -56,10 +56,16 @@ void ThermoXImpl::extrapolate_dlnp(torch::Tensor temp, torch::Tensor pres,
     std::cout << "Extrapolating adiabat with dlnp = " << dlnp << std::endl;
   }
 
+  int ngas = options->vapor_ids().size();
+  int ncloud = options->cloud_ids().size();
+
   auto conc = compute("TPX->V", {temp, pres, xfrac});
   auto entropy_vol = compute("TPV->S", {temp, pres, conc});
   auto entropy_mole0 = entropy_vol / conc.sum(-1);
   auto entropy_target = entropy_mole0 + ds_dlnp * dlnp;
+
+  // dry-gas mole fraction (dry never condenses; reference for rain-out)
+  auto x_dry0 = conc.select(-1, 0) / conc.sum(-1);
 
   if (verbose) {
     std::cout << "Initial State: T = [" << temp.min().item<double>() << ", "
@@ -84,9 +90,25 @@ void ThermoXImpl::extrapolate_dlnp(torch::Tensor temp, torch::Tensor pres,
   while (iter++ < options->max_iter()) {
     xfrac.copy_(xfrac0);
     auto gain = forward(temp, pres, xfrac);
+
+    // pseudo-adiabat: the departing condensate carries its own molar entropy
+    // s_cond away, d(n_gas * s_gas) = -sum_j s_cond,j * dn_j. Per mole of
+    // (conserved) dry air the entropy target for the rained-out gas is then
+    //   (x_dry_new / x_dry0) * s0 - sum_j s_cond,j * conc_cloud,j / n_gas
+    auto entropy_step = entropy_target;
     if (opts.rainout()) {
-      xfrac.narrow(-1, options->vapor_ids().size(),
-                   options->cloud_ids().size()) = 0.;
+      auto conc_full = compute("TPX->V", {temp, pres, xfrac});
+      auto scond = eval_entropy_R(temp, pres, conc_full, stoich, options)
+                       .narrow(-1, ngas, ncloud) *
+                   constants::Rgas;
+      auto n_gas = conc_full.narrow(-1, 0, ngas).sum(-1);
+      auto x_dry_new = conc_full.select(-1, 0) / n_gas;
+      auto cloud_flux =
+          (scond * conc_full.narrow(-1, ngas, ncloud)).sum(-1) / n_gas;
+      entropy_step =
+          (x_dry_new / x_dry0) * entropy_mole0 - cloud_flux + ds_dlnp * dlnp;
+
+      xfrac.narrow(-1, ngas, ncloud) = 0.;
       xfrac /= xfrac.sum(-1, true);
     }
 
@@ -115,12 +137,12 @@ void ThermoXImpl::extrapolate_dlnp(torch::Tensor temp, torch::Tensor pres,
       std::cout << "}" << std::endl;
     }
 
-    if ((entropy_target - entropy_mole).abs().max().item<double>() <
+    if ((entropy_step - entropy_mole).abs().max().item<double>() <
         10 * options->ftol()) {
       break;
     }
 
-    temp *= 1. + (entropy_target - entropy_mole) / cp_mole;
+    temp *= 1. + (entropy_step - entropy_mole) / cp_mole;
   }
 
   if (iter >= options->max_iter()) {
@@ -142,10 +164,16 @@ void ThermoXImpl::extrapolate_dz(torch::Tensor temp, torch::Tensor pres,
               << " with gravity = " << grav << " m/s^2" << std::endl;
   }
 
+  int ngas = options->vapor_ids().size();
+  int ncloud = options->cloud_ids().size();
+
   auto conc = compute("TPX->V", {temp, pres, xfrac});
   auto rho0 = compute("V->D", {conc});
   auto entropy_mole0 = compute("TPV->S", {temp, pres, conc}) / conc.sum(-1);
   auto entropy_target = entropy_mole0 + ds_dz * dz;
+
+  // dry-gas mole fraction (dry never condenses; reference for rain-out)
+  auto x_dry0 = conc.select(-1, 0) / conc.sum(-1);
 
   if (verbose) {
     std::cout << "Initial State: T = [" << temp.min().item<double>() << ", "
@@ -174,9 +202,22 @@ void ThermoXImpl::extrapolate_dz(torch::Tensor temp, torch::Tensor pres,
   while (iter++ < options->max_iter()) {
     xfrac.copy_(xfrac0);
     auto gain = forward(temp, pres, xfrac);
+
+    // pseudo-adiabat rain-out entropy target; see extrapolate_dlnp
+    auto entropy_step = entropy_target;
     if (opts.rainout()) {
-      xfrac.narrow(-1, options->vapor_ids().size(),
-                   options->cloud_ids().size()) = 0.;
+      auto conc_full = compute("TPX->V", {temp, pres, xfrac});
+      auto scond = eval_entropy_R(temp, pres, conc_full, stoich, options)
+                       .narrow(-1, ngas, ncloud) *
+                   constants::Rgas;
+      auto n_gas = conc_full.narrow(-1, 0, ngas).sum(-1);
+      auto x_dry_new = conc_full.select(-1, 0) / n_gas;
+      auto cloud_flux =
+          (scond * conc_full.narrow(-1, ngas, ncloud)).sum(-1) / n_gas;
+      entropy_step =
+          (x_dry_new / x_dry0) * entropy_mole0 - cloud_flux + ds_dz * dz;
+
+      xfrac.narrow(-1, ngas, ncloud) = 0.;
       xfrac /= xfrac.sum(-1, true);
     }
 
@@ -203,7 +244,7 @@ void ThermoXImpl::extrapolate_dz(torch::Tensor temp, torch::Tensor pres,
       std::cout << "}" << std::endl;
     }
 
-    if ((entropy_target - entropy_mole).abs().max().item<double>() <
+    if ((entropy_step - entropy_mole).abs().max().item<double>() <
         10 * options->ftol()) {
       break;
     }
@@ -216,7 +257,7 @@ void ThermoXImpl::extrapolate_dz(torch::Tensor temp, torch::Tensor pres,
     auto rho = compute("V->D", {conc});
     pres.set_(pres0 - 0.5 * (rho + rho0) * grav * dz);
     auto dlnp = pres.log() - pres1.log();
-    temp.set_(temp1 * (1. + (entropy_target - entropy_mole +
+    temp.set_(temp1 * (1. + (entropy_step - entropy_mole +
                              xg * constants::Rgas * dlnp) /
                                 cp_mole));
     conc = compute("TPX->V", {temp, pres, xfrac});

--- a/src/thermo/thermo_y.cpp
+++ b/src/thermo/thermo_y.cpp
@@ -362,7 +362,15 @@ void ThermoYImpl::_pres_to_temp(torch::Tensor pres, torch::Tensor ivol,
     auto cv_R = eval_cv_R(out, conc_gas, options);
     auto cp_R = eval_cp_R(out, conc_gas, options);
     auto temp_pre = out.clone();
-    out += func / ((cp_R - cv_R) * conc_gas).sum(-1);
+    // Newton: T <- T - f/f'.  f = T*sum(cz*c) - P/R increases with T, so the
+    // step must be SUBTRACTED. (cp_R-cv_R)*c >= f' = sum(cz + T dcz/dT)*c for a
+    // dissociating gas (Mayer: cp-cv = (z+T z_T)^2/(z+c z_c) with z_T>0,
+    // z_c<0), so this is a safely damped Newton. The old '+=' doubled the error
+    // each iteration; it was invisible because for cz == 1 the initial guess T0
+    // = P/(R*sum c) is already exact (func == 0) and the loop exits at once.
+    // use_h2_dissociation is the first cz != 1 consumer and made PV->T diverge
+    // (3900 -> 17000 K).
+    out -= func / ((cp_R - cv_R) * conc_gas).sum(-1);
     if ((1. - temp_pre / out).abs().max().item<double>() < options->ftol()) {
       break;
     }


### PR DESCRIPTION
## Summary

`extrapolate_*(rainout=true)` — the `setup_profile(method="pseudo-adiabat")` path — holds the gas
molar entropy `s̄_g` constant along ascent, i.e. it builds a constant-θ surface in the Eq-24 sense of
the theory paper (S_g/n). But a rained-out parcel doesn't conserve that θ: the departing condensate
carries its own molar entropy away, so `d(n_g·s̄_g) = −s_j†·dn` (Eq-11 `s_j†`), not `−s̄_g·dn`. This
is a definition gap (the constant-θ surface vs the pseudo-adiabatic parcel path), not an entropy-data
error — the entropy function and the saturation-adjustment runtime are correct.

## Why the old builder is provably wrong (oracle-free)

Holding `s̄_g` constant leaves the dry species' **arbitrary entropy reference** in the answer, because
`x_dry/x_gas` varies as vapor rains out. So the built adiabat **moves when you shift the dry entropy
zero** — which a physical parcel path cannot do. Shifting the dry reference by δ moves the
super-adiabaticity `θ(1 bar) − θ(20 bar)` linearly: **1.66 K per 100 J/mol/K** on a Jupiter
`H2O-NH3` config, and −0.24 K/100 on a Neptune H₂S config (matching the analytic
`(s_j† − s̄_g)·Σdn/(n·c̄p)` prediction to 0.3%). Same builder, same `forward()`; only the entropy zero
changed.

## The fix (~50 lines, `extrapolate_ad.cpp` only)

Per mole of the conserved dry air, set the Newton target for the rained-out gas to

```
s̄_new = (x_dry_new / x_dry0) * s̄0  −  Σ_j s_j† * conc_cloud,j / n_gas
```

with `s_j†` from `eval_entropy_R(...,options)`'s condensate slots (no new data, no new API).
Reference-invariant by construction; reduces to the old code exactly on any unsaturated step. The
non-rainout (`moist`/reversible) path is unchanged and stays bit-identical.

## Validation

- reference-invariant: d(super-adiabaticity)/d(reference) = 0.0000 (was 1.66 K/100);
- lands the day-0 super-adiabaticity on the analytic Li & Ingersoll χ-formula value (Neptune: builder
  went from −0.526 K to −0.277 K vs the χ-formula −0.28 K; the old code ran ~1.9× the L&I latent
  response);
- matches an independent NumPy re-implementation of the loop to **1.7e-13 K** (bit-exact);
- an unmodified 2-D moist CRM runner (100×100) builds the corrected IC and runs clean to the cycle
  limit on the patched build (RC=0, no NaN, no convergence warning);
- Python tests pass (`test_earth.py`, `test_h2diss_ndfield.py`); the `moist`/`dry` adiabat columns are
  bit-identical to the unpatched build (the C++ `extrapolate_ad`/`moist_adiabat` tests exercise only
  the `rainout=false` path, which this change leaves untouched).

## Also in this PR (small, independent fixes, each its own commit)

- **`species.cpp` reads the wrong key for `s0_R`** — it read `sp["u0_R"]` under the `s0_R` guard, so a
  config setting a species reference *entropy* silently got its reference *energy* (or threw). Present
  since #15; latent because no shipped config sets `s0_R`. Verified: setting `s0_R` now shifts the
  entropy by `conc·s0·R` and is independent of `u0_R`.
- **`TPV->S` NaN at a zero mole fraction** — the gas `−ln(x)` term gave `−inf` for `x=0`, and the
  `conc·s` sum then produced `0·inf = NaN`. Guarded by clamping the ratio before the log; an absent
  species contributes 0, any real mole fraction is unchanged. Verified finite with a vapor forced to 0.
- **Newton sign in `_pres_to_temp`** — the P→T update used `+=` where Newton must subtract, doubling
  the error each iteration. **Bit-identical for every current (`cz==1`) EOS** (the loop exits on
  iteration one), so it only affects a `cz!=1` EOS; included as a latent-bug fix.

## Scope

The numerical change to a given IC scales with condensable abundance — small for a low-abundance
H₂O/NH₃ Jupiter case (~0.03 K in the troposphere), several tenths of a K for wetter / higher-abundance
atmospheres. The defect (a reference-dependent builder) is config-independent. The `moist`/reversible
branch is correct (its offset from the pseudo-adiabat is genuine non-dilute loading) and is unchanged.
A compact reference-invariance test for the rainout path (which currently has none) can follow.
