### PR TITLE
fix: free two leaked scratch buffers on the CPU path (conc0 in equilibrate_uv, skip_row in leastsq_kkt)

### DIFF
--- a/src/math/leastsq_kkt.h
+++ b/src/math/leastsq_kkt.h
@@ -333,6 +333,7 @@ DISPATCH_MACRO int leastsq_kkt(T* b, T const* a, T const* c, T const* d, int n1,
     free(eval);
     free(ct_indx);
     free(lu_indx);
+    free(skip_row);
   }
 
   if (iter >= *max_iter) {

--- a/src/thermo/equilibrate_uv.h
+++ b/src/thermo/equilibrate_uv.h
@@ -318,6 +318,7 @@ DISPATCH_MACRO int equilibrate_uv(
     free(weight);
     free(rhs);
     free(stoich_active);
+    free(conc0);
     free(gain_cpy);
   }
 


### PR DESCRIPTION
equilibrate_uv() allocates nine scratch buffers in the `work == nullptr` branch but the cleanup block frees only eight — `conc0` is never freed, leaking `nspecies * sizeof(T)` bytes per call.

### Impact
`call_equilibrate_uv_cpu` invokes the kernel once per grid cell with `work == nullptr`, and snapy s ideal-moist EOS calls it every cycle inside `Mesh::forward`, so RSS grows linearly and without bound.

Measured on the UM-JUPITER F10 CRM 2-D case (100x100, 7 species, single rank, CPU):

| build | leak |
|---|---|
| snapy #188 + kintera `xiz/inline-svp` (Lux) | 73.1 B/cell/cycle |
| same (NASA/HECC) | 72.8 B/cell/cycle |
| released wheels snapy 2.9.2 + kintera 2.4.6 (macOS arm64) | 72.7 B/cell/cycle |

Linear with R^2 ~ 0.999 over 6000 cycles; `malloc_trim(0)` reclaims essentially none of it, confirming the memory is retained rather than allocator-cached. A 25-rank production run reached ~190 GB and was OOM-killed.

### Scope
- **CPU only.** `thermo_dispatch.cu` sizes a workspace via `equilibrate_uv_space()` and passes it in, so `conc0` comes from the `alloc_from` bump allocator and is not individually freed by design.
- `equilibrate_tp()` is unaffected — it allocates seven buffers and frees all seven.
- Requires condensate species only because `equilibrate_uv()` returns early when `nreaction <= 0`, so a case with no condensation reactions never reaches the allocation.

### Fix
One line: `free(conc0)` in the `work == nullptr` cleanup block, in allocation order.

### Note (not part of this fix)
The CPU path does nine `malloc`/`free` pairs *per cell per call*. Passing a workspace arena the way the CUDA path does would remove that overhead entirely — worth considering separately.