### PR TITLE
thermo: rebuild the equilibrate_tp gain matrix at the converged state

### DIFF
--- a/src/thermo/equilibrate_tp.h
+++ b/src/thermo/equilibrate_tp.h
@@ -279,7 +279,7 @@ DISPATCH_MACRO int equilibrate_tp(T* gain, T* diag, T* xfrac, T temp, T pres,
     for (int i = 0; i < nspecies; i++) xfrac[i] /= xsum;
   }
 
-  /*///////// Construct a gain matrix of active reactions ///////////
+  /////////// Construct a gain matrix of active reactions ///////////
   int first = 0;
   int last = nreaction;
   T xg = 0.0;
@@ -329,8 +329,6 @@ DISPATCH_MACRO int equilibrate_tp(T* gain, T* diag, T* xfrac, T temp, T pres,
     }
 
   mmdot(gain_cpy, weight, stoich_active, *nactive, nspecies, *nactive);
-  */
-  memcpy(gain_cpy, gain, nreaction * nreaction * sizeof(T));
   memset(gain, 0, nreaction * nreaction * sizeof(T));
 
   for (int k = 0; k < (*nactive); k++) {

--- a/src/thermo/extrapolate_ad.cpp
+++ b/src/thermo/extrapolate_ad.cpp
@@ -26,13 +26,31 @@ torch::Tensor ThermoXImpl::effective_cp(torch::Tensor temp, torch::Tensor pres,
 
   auto logsvp_ddT = LogSVPFunc::grad(temp);
 
+  // Row-equilibrate before the solve. The gain rows are scaled by 1/x_vapour,
+  // so a species that has largely rained out contributes a row of order 1e14
+  // next to the order-1e2 row that actually carries the latent heat: cond(gain)
+  // ~ x_j / x_k, and the row that carries ~100 % of cp_latent is the SMALL one.
+  // linalg_lstsq's rank tolerance is RELATIVE, so it discards exactly that
+  // direction -- measured on a CH4 + H2S column, cp_latent comes out EXACTLY
+  // zero in float32 once cond(gain) > ~1e7 (and a single active reaction
+  // sitting beside an inactive all-zero row already fails). Dividing each row,
+  // and the matching right-hand side, by that row's largest magnitude gives the
+  // identical solution in exact arithmetic with a condition number of order 1.
+  // Rows that are entirely zero (inactive reactions) keep a scale of 1 and stay
+  // zero.
+  auto row_scale = gain.abs().amax(-1, /*keepdim=*/true);
+  row_scale =
+      torch::where(row_scale > 0., row_scale, torch::ones_like(row_scale));
+  auto gain_eq = gain / row_scale;
+  auto rhs_eq = logsvp_ddT / row_scale.squeeze(-1);
+
   torch::Tensor rate_ddT;
 
   if (gain.device().is_cpu()) {
-    rate_ddT = std::get<0>(torch::linalg_lstsq(gain, logsvp_ddT));
+    rate_ddT = std::get<0>(torch::linalg_lstsq(gain_eq, rhs_eq));
   } else {
-    auto pinv = torch::linalg_pinv(gain, /*atol=*/1e-6);
-    rate_ddT = pinv.matmul(logsvp_ddT.unsqueeze(-1)).squeeze(-1);
+    auto pinv = torch::linalg_pinv(gain_eq, /*atol=*/1e-6);
+    rate_ddT = pinv.matmul(rhs_eq.unsqueeze(-1)).squeeze(-1);
   }
 
   auto enthalpy =


### PR DESCRIPTION
## What is wrong

`effective_cp` (Li 2026 §3.3, eq 85/91) needs the gain matrix **G = W·S of the reactions sitting *on* their phase boundary at the converged composition**. The block that rebuilds it at the end of `equilibrate_tp` has been commented out since #50 (`5304aae`, 2025-09-09) and replaced by

```c
memcpy(gain_cpy, gain, nreaction * nreaction * sizeof(T));
```

i.e. a copy of whatever `gain` still held from the last equilibration pass that computed one. That copy is (a) one pass stale, (b) built from the *out-of-equilibrium* set rather than the *on-boundary* set, and (c) scattered through a `reaction_set` that the final (breaking) pass has since re-permuted.

**With two or more condensation reactions the exported matrix is therefore garbage.** On an H2/He + CH4 + H2S column, at 75.84 K / 0.820 bar, every entry is zero except the CH4 slot — and that slot holds the **H2S** reaction's weight:

| | measured | expected |
|---|---|---|
| `gain[CH4][CH4]` | `-1.45640e+08` | `-6.11420e+01` |
| `gain[H2S][H2S]` | `0` | `-1.45556e+08` |
| off-diagonals | `0` | `+1.00216` |

`-1.45640e+08` is `-(1/x_H2S - 1/x_g)`, and it tracks that quantity to 5–6 significant figures over eight orders of magnitude as H2S rains out up the column.

## What it costs

`rate_ddT = lstsq(gain, logsvp_ddT)` comes back ≈ 0, the latent term of `effective_cp` collapses to ~1e-5 J/mol/K, and `extrapolate_dz` / `extrapolate_dlnp` run their Newton iteration on the **frozen (dry) heat capacity**:

| P [bar] | `cp_mole` used | −T dR/dT (central FD of the loop's own residual) | λ = 1 − ratio | observed residual decay | iterations |
|---|---|---|---|---|---|
| 0.954 | 28.146 | 28.157 | −0.0004 | — | 3 |
| 0.885 | 28.144 | **52.311** | **−0.859** | **−0.860** | 30 (fail) |
| 0.820 | 28.140 | 50.120 | −0.781 | −0.78 | 30 (fail) |
| 0.704 | 28.133 | 45.818 | −0.629 | — | 25 |
| 0.238 | 28.112 | 29.152 | −0.037 | — | 5 |

The step overshoots by `cp†/cp_bar`, so the iteration alternates in sign and converges *geometrically* with multiplier λ ≈ −0.86 — which reproduces both the observed decay ratio and the whole iteration-count profile up the column. It cannot reach `ftol` in 30 iterations, and reports

```
Warning: extrapolate_ad does not converge after 30 iterations. (function extrapolate_dz)
```

Worth noting the threshold: |λ| > 1 — genuine divergence rather than slow convergence — needs only `cp†/cp_bar > 2`. This column reaches 1.86.

**Single-reaction mechanisms are unaffected** (measured error 0.00 %: the one-pass staleness is ~1e-5 relative, and with one reaction the index scatter is trivially the identity), which is presumably why this went unnoticed.

## Why the rebuild is necessary — no cheaper fix works

The obvious smaller fix is to remember the `reaction_set` / `nactive` that belong to the stored matrix. That does not work, because **two different things are called "the active set" and at convergence they are near-opposites**:

- the loop's active set is *"reactions still **out of** equilibrium"* — and it is empty when the loop exits, since that is the exit condition (`if (first == 0) break`);
- what `effective_cp` needs is *"reactions **on** the phase boundary"* — precisely the ones that **are** in equilibrium.

So in the trace above, CH4's own row was never computed at all: CH4 had already reached equilibrium and therefore never entered the loop's active set. Even with a perfect index map its row would be zero and the latent term would still vanish. The information has to be derived once at the end, with a different test, from the converged composition — which is exactly what the disabled block does.

## The patch

Re-enable the block and drop the copy that replaced it. The restored code is byte-identical (whitespace-normalised, 44 code lines) to what was in the file before `5304aae`. It also removes a latent uninitialised read of `*nactive` when the equilibration loop breaks on its first pass.

## Verification

- **`gain[CH4][CH4]` → `-6.11420e+01`**, matching `-(1/x_CH4 - 1/x_g)`; the H2S slot and the off-diagonals appear where they were zero.
- **`effective_cp` vs the analytic cp† of eq (85)/(91): −46.1 % → +0.0 %**; vs a central FD of the loop's own residual: −46 % → −0.15 %.
- **Newton multiplier λ: −0.86 → −0.0015**; iterations at the five in-cloud levels 30(fail)/30/30/25/14 → **5/4/5/5/5**; warnings per 200-level column **3 → 0**.
- **The equilibrium composition is bit-identical** before and after — all mole fractions, 17 significant digits, at six probe states from 120 bar/329 K to 0.216 bar/54.8 K. The patch only touches code that runs after the equilibration loop, and the measurement confirms it.
- **The converged profile is bit-identical.** Marched from the same surface state at `max-iter` 2000 / `ftol` 1e-13, patched and unpatched agree to **max |ΔT| = 0.0000 mK** over 200 levels. The fix changes the cost of reaching the answer, not the answer.
- **A previously unreachable tolerance becomes cheap:** at `max-iter` 30 / `ftol` 1e-13 the patched build reproduces the brute-force column exactly with zero warnings; unpatched, the same settings fail at seven levels and land 5.1 mK away.
- **Zero-abundance edge cases stay finite.** The restored block has no `xfrac[i] > 0` guard (the loop above it does). Tested with each vapour, and both, set to exactly zero: `gain` finite everywhere and `effective_cp` correctly falls back to the frozen value — `log(0) = -inf` fails the on-boundary test, so the reaction is excluded and no NaN reaches `weight`.
- **Downstream regression suite: 24/24 pass, zero warnings on every case** (a 24-case CPU+GPU battery of hydro / moist-cloud / RT / cubed-sphere / determinism examples in a consumer project, run with this build overlaid).

## Reproducer

<details><summary><code>repro_gain.yaml</code> + <code>repro_gain.py</code> (self-contained, ~40 lines)</summary>

```yaml
reference-state: {Tref: 0., Pref: 1.e5}
species:
  - {name: dry,    composition: {H: 1.768, He: 0.115873}, cv_R: 2.381}
  - {name: H2S,    composition: {H: 2, S: 1}, cv_R: 6.696, u0_R: 0.}
  - {name: CH4,    composition: {C: 1, H: 4}, cv_R: 2.623, u0_R: 0.}
  - {name: H2S(s), composition: {H: 2, S: 1}, cv_R: 7.696, u0_R: -2231.3}
  - {name: CH4(s), composition: {C: 1, H: 4}, cv_R: 3.623, u0_R: -1009.4}
reactions:
  - equation: H2S => H2S(s)
    type: nucleation
    rate-constant: {formula: ideal, T3: 187.66, P3: 23200, beta: 11.89, gamma: 0.0, betas: 11.89, gammas: 0.0}
  - equation: CH4 => CH4(s)
    type: nucleation
    rate-constant: {formula: ideal, T3: 90.69, P3: 11696, beta: 11.13, gamma: 0.0, betas: 11.13, gammas: 0.0}
dynamics:
  equation-of-state: {type: ideal-moist, max-iter: 30, ftol: 1.e-6}
```

```python
import os, numpy as np, torch, kintera
from kintera import ThermoX, ThermoOptions
CFG  = os.path.join(os.path.dirname(os.path.abspath(__file__)), "repro_gain.yaml")
SVP  = [("H2S", 187.66, 23200.0, 11.89), ("CH4", 90.69, 11696.0, 11.13)]   # reaction order
op = ThermoOptions.from_yaml(CFG); tx = ThermoX(op); tx.to(torch.float64)
names, ngas = op.species(), len(op.vapor_ids())
temp  = torch.tensor([[75.84]], dtype=torch.float64)          # inside both clouds
pres  = torch.tensor([[0.82041e5]], dtype=torch.float64)
xfrac = torch.zeros((1, 1, len(names)), dtype=torch.float64)
xfrac[..., names.index("H2S")] = 8.553475e-4
xfrac[..., names.index("CH4")] = 1.738739e-2
xfrac[..., 0] = 1.0 - xfrac[..., 1:].sum(dim=-1)
gain = tx(temp, pres, xfrac)
G  = np.array(gain.reshape(len(SVP), len(SVP)).tolist())
xg = float(xfrac[..., :ngas].sum(-1))
print("gain =\n", G)
for j, (nm, t3, p3, beta) in enumerate(SVP):
    xv = float(xfrac[..., names.index(nm)])
    print(f"{nm:>5} x={xv:.5e} gain[j][j]={G[j][j]:.5e} expected={-(1/xv - 1/xg):.5e}")
xgas = xfrac.clone(); xgas[..., ngas:] = 0.0; xgas = xgas / xgas.sum(-1, keepdim=True)
conc = tx.compute("TPX->V", [temp, pres, xgas])
cp_k = float(tx.effective_cp(temp, pres, xgas, gain, conc))
cp_f = float(tx.effective_cp(temp, pres, xgas, torch.zeros_like(gain), conc))
act  = [j for j, (nm, *_) in enumerate(SVP) if float(xfrac[..., names.index(nm + "(s)")]) > 0.0]
Ga = np.array([[1.0/xg - (1.0/float(xfrac[..., names.index(SVP[j][0])]) if a == b else 0.0)
                for b in range(len(act))] for a, j in enumerate(act)])
fp = np.array([SVP[j][3]*SVP[j][1]/float(temp)**2 for j in act])
cp_x = cp_f + sum(-(kintera.constants.Rgas*SVP[j][3]*SVP[j][1])*d
                  for j, d in zip(act, np.linalg.solve(Ga, fp)))
print(f"frozen {cp_f:.4f}   analytic cp_dagger {cp_x:.4f}   kintera effective_cp {cp_k:.4f}"
      f"  ({100*(cp_k/cp_x-1):+.1f} %)")
t2, p2, x2 = temp.clone(), pres.clone(), xfrac.clone()
x2[...] = 0.; x2[..., names.index("H2S")] = 8.553475e-4; x2[..., names.index("CH4")] = 1.738739e-2
x2[..., 0] = 1.0 - x2[..., 1:].sum(dim=-1)
tx.extrapolate_dz(t2, p2, x2, 1750.0, grav=11.15, rainout=True)
print(f"one extrapolate_dz step of 1750 m -> T = {float(t2):.6f} K")
```

Output before / after:

| | current `main` | with this patch |
|---|---|---|
| `gain[H2S][H2S]` vs expected | `0` vs `-1.45556e+08` | `-1.45556e+08` vs `-1.45556e+08` |
| `gain[CH4][CH4]` vs expected | `-1.45640e+08` vs `-6.11420e+01` | `-6.11420e+01` vs `-6.11420e+01` |
| frozen cp / analytic cp† | 28.1436 / 52.2320 | 28.1436 / 52.2320 |
| `effective_cp` | 28.1436 (**−46.1 %**) | 52.2325 (**+0.0 %**) |
| convergence warning | yes | none |

</details>

## One thing I did not change

`src/thermo/equilibrate_uv.h` carries the same `memcpy` / `memset` / scatter sequence (lines 299–300) but never had a rebuild block, and its `gain` currently has no consumer — so it is dormant rather than wrong. Left alone deliberately; worth a look before anything starts using it.
